### PR TITLE
GooglePlay、GameCenter両方に対応したスクリプト作成

### DIFF
--- a/GooglePlayGameTest/Assets/AchievementController.cs
+++ b/GooglePlayGameTest/Assets/AchievementController.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// 以下の3つはGooglePlayGamesの機能を使用するためのもの
+using GooglePlayGames;
+using GooglePlayGames.BasicApi;
+using UnityEngine.SocialPlatforms;
+
+/// <summary>
+/// GooglePlay実績管理クラス
+/// </summary>
+public class AchievementController : MonoBehaviour
+{
+    const int AchievementNum = 5;                            // 実績の総数
+
+    readonly string[] AchievementIDs = {                     // 実績ID群
+#if UNITY_ANDROID
+        "CgkI_vDQ3ZYdEAIQAQ",                                // 実績１：初ジャンプ
+        "CgkI_vDQ3ZYdEAIQAg",                                // 実績２：宇宙到達
+        "CgkI_vDQ3ZYdEAIQAw",                                // 実績３：太陽系制覇
+        "CgkI_vDQ3ZYdEAIQBA",                                // 実績４：開始後、放置
+        "CgkI_vDQ3ZYdEAIQBQ",                                // 実績５：15回ジャンプ
+        "CgkI_vDQ3ZYdEAIQBw"                                 // 実績６：30回ジャンプ
+#elif UNITY_IOS
+        "firstjump",                                         // 実績１：初ジャンプ
+        "spacecame",                                         // 実績２：宇宙到達
+        "planetarycature",                                   // 実績３：太陽系制覇
+        "pleasefly",                                         // 実績４：開始後、放置
+        "fifteenjump",                                       // 実績５：15回ジャンプ
+        "thirtyjump"                                         // 実績６：30回ジャンプ
+#endif
+    };
+
+    bool[] isReleased = new bool[AchievementNum];            // 実績解除状況
+
+
+    /// <summary>
+    /// 開始
+    /// </summary>
+    void Start()
+    {
+        // 実績解除状況初期化
+        for (int i = 0; i < AchievementNum; i++)
+        {
+            isReleased[i] = false;
+        }
+    }
+
+    /// <summary>
+    /// 実績解除
+    /// </summary>
+    /// <param num="id">実績の番号</param>
+    /// <param name="id">実績ID</param>
+    /// <param name="progress">実績の進捗（0で非表示解除、100で実績解除）</param>
+    void ReleaseAchievement(int num, string id, float progress)
+    {
+        // 解除処理
+        Social.ReportProgress(id, progress, (bool success) => {
+            if (success)
+            {
+                // 解除に成功したら解除状況を更新
+                isReleased[num] = true;
+            }
+        });
+    }
+
+    /// <summary>
+    /// 実績一覧表示
+    /// </summary>
+    public void ShowAchievements()
+    {
+        Social.ShowAchievementsUI();
+    }
+}

--- a/GooglePlayGameTest/Assets/AchievementController.cs.meta
+++ b/GooglePlayGameTest/Assets/AchievementController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e4e3be0d22d57f418435eac64a10686
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GooglePlayGameTest/Assets/LeaderboardController.cs
+++ b/GooglePlayGameTest/Assets/LeaderboardController.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+// 以下の3つはGooglePlayGamesの機能を使用するためのもの
+using GooglePlayGames;
+using GooglePlayGames.BasicApi;
+using UnityEngine.SocialPlatforms;
+
+/// <summary>
+/// リーダーボード管理クラス
+/// </summary>
+public class LeaderboardController : MonoBehaviour
+{
+    [SerializeField]
+    InputField inputField;                                   // 仮でスコアを登録するための入力欄
+
+    readonly string LeaderboardID =                          // リーダーボードID
+#if UNITY_ANDROID
+        "CgkI_vDQ3ZYdEAIQBg";
+#elif UNITY_IOS
+        "maxdistance";
+#endif
+
+    long score = 0;                                          // リーダーボードへ登録するスコア
+
+    /// <summary>
+    /// リーダーボードへスコアを登録
+    /// </summary>
+    public void RegisterScoreToLeaderboard()
+    {
+        // 入力された値をlong型に変換
+        score = long.Parse(inputField.text);
+
+        // スコア登録処理（成功時になにか処理をしたりはしないので空にしてます）
+        Social.ReportScore(score, LeaderboardID, (bool success) => {});
+    }
+
+    /// <summary>
+    /// リーダーボード表示
+    /// </summary>
+    public void ShowLeaderboard()
+    {
+        Social.ShowLeaderboardUI();
+    }
+}

--- a/GooglePlayGameTest/Assets/LeaderboardController.cs.meta
+++ b/GooglePlayGameTest/Assets/LeaderboardController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bc7b699790da8541abd566c261b132c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GooglePlayGameTest/Assets/SignInController.cs
+++ b/GooglePlayGameTest/Assets/SignInController.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+// 以下の3つはGooglePlayGamesの機能を使用するためのもの
+using GooglePlayGames;
+using GooglePlayGames.BasicApi;
+using UnityEngine.SocialPlatforms;
+
+/// <summary>
+/// サインイン管理クラス
+/// </summary>
+public class SignInController : MonoBehaviour
+{
+    public bool IsSignIn { get; private set; }    // サインインしているかどうか
+
+    const int MaxSignInTryCount = 20;             // 最大サインイン処理実行回数
+    int signInTryCount = 0;                       // サインイン処理実行回数
+
+    /// <summary>
+    /// 開始
+    /// </summary>
+    void Awake()
+    {
+#if UNITY_ANDROID
+
+        // PlayGames初期化
+        PlayGamesClientConfiguration config = new PlayGamesClientConfiguration.Builder().Build();
+
+        PlayGamesPlatform.InitializeInstance(config);
+        PlayGamesPlatform.Activate();
+#endif
+
+        IsSignIn = false;
+
+        // サインイン実行
+        SignIn();
+    }
+
+    /// <summary>
+    /// 「GooglePlay」、「GameCenter」へのサインイン
+    /// </summary>
+    void SignIn()
+    {
+        // サインイン処理
+        Social.localUser.Authenticate((bool success) => {
+            if (success)
+            {
+                // サインイン成功！
+                IsSignIn = true;
+            }
+            else if (signInTryCount < MaxSignInTryCount)
+            {
+                // サインインに失敗して、処理実行回数が最大に達していないなら再度実行
+                SignIn();
+            }
+        });
+
+        // サインイン処理実行回数をカウント
+        signInTryCount++;
+    }
+}

--- a/GooglePlayGameTest/Assets/SignInController.cs.meta
+++ b/GooglePlayGameTest/Assets/SignInController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cf0f1dfa72f8514484f379e9577ee87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
・GooglePlay、GameCenter両方のサインイン、リーダーボード、実績機能
　に対応したスクリプトを作成
・PlayGamesプラグインに「AchievementManager.cs」などのスクリプトがもともとあったため、
　「～Controller.cs」という名前にしてます。