### PR TITLE
 Re-再生が終了したSEのオブジェクトの後処理

### DIFF
--- a/BattaJump/Assets/Scenes/MainGame.unity
+++ b/BattaJump/Assets/Scenes/MainGame.unity
@@ -176,6 +176,7 @@ Transform:
   - {fileID: 1832378100}
   - {fileID: 1436964731}
   - {fileID: 2075425990}
+  - {fileID: 576746849}
   m_Father: {fileID: 1837509956}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5451,6 +5452,50 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
+--- !u!1 &576746848
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 576746849}
+  - component: {fileID: 576746850}
+  m_Layer: 0
+  m_Name: EndedSe
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &576746849
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576746848}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3626069}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &576746850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576746848}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5307f008f9bbdb94bb647f327be0a565, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  childAmountMax: 30
 --- !u!1 &616551224
 GameObject:
   m_ObjectHideFlags: 0
@@ -5950,6 +5995,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Name: 
   m_EditorClassIdentifier: 
   m_Name: 
@@ -6856,13 +6905,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1716856317}
-  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalRotation: {x: 0.9013343, y: -0.03291763, z: -0.116934836, w: 0.4157394}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+  m_LocalEulerAnglesHint: {x: 132.12, y: 20.8, z: 13.5}
 --- !u!1 &1784750480
 GameObject:
   m_ObjectHideFlags: 0
@@ -7490,6 +7539,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2075425990}
+  - component: {fileID: 2075425991}
   m_Layer: 0
   m_Name: PlayingSes
   m_TagString: Untagged
@@ -7511,3 +7561,16 @@ Transform:
   m_Father: {fileID: 3626069}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2075425991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2075425989}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c0e2da6d2f86f640afb14d317f85c2c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parentEndSe: {fileID: 576746849}

--- a/BattaJump/Assets/Scenes/MainGame.unity
+++ b/BattaJump/Assets/Scenes/MainGame.unity
@@ -5985,24 +5985,6 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1.8, z: 1}
   m_Center: {x: 0, y: 0.89, z: 0}
---- !u!114 &963990972
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963990966}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1035635572
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/BattaJump/Assets/Script/Audio/EndedSeDestroyer.cs
+++ b/BattaJump/Assets/Script/Audio/EndedSeDestroyer.cs
@@ -16,7 +16,7 @@ public class EndedSeDestroyer : MonoBehaviour
     void Update()
     {
         // 子オブジェクトの最大数を超えたら
-        if (transform.childCount == childAmountMax)
+        if (transform.childCount > childAmountMax)
         {
             // 再生が終了したSEの子オブジェクトを一斉に削除する
             foreach (Transform endedSeChild in transform)

--- a/BattaJump/Assets/Script/Audio/EndedSeDestroyer.cs
+++ b/BattaJump/Assets/Script/Audio/EndedSeDestroyer.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 再生が終了したSEオブジェクトの削除処理
+/// </summary>
+public class EndedSeDestroyer : MonoBehaviour
+{
+    // 子オブジェクトの最大数
+    [SerializeField] int childAmountMax = 0;
+
+    /// <summary>
+    /// 更新
+    /// </summary>
+    void Update()
+    {
+        // 子オブジェクトの最大数を超えたら
+        if (transform.childCount == childAmountMax)
+        {
+            // 再生が終了したSEの子オブジェクトを一斉に削除する
+            foreach (Transform endedSeChild in transform)
+            {
+                Destroy(endedSeChild.gameObject);
+            }
+        }
+    }
+}

--- a/BattaJump/Assets/Script/Audio/EndedSeDestroyer.cs.meta
+++ b/BattaJump/Assets/Script/Audio/EndedSeDestroyer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5307f008f9bbdb94bb647f327be0a565
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/BattaJump/Assets/Script/Audio/PlayingSeParentSwitcher.cs
+++ b/BattaJump/Assets/Script/Audio/PlayingSeParentSwitcher.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 再生中のSEのオブジェクトを監視して、親オブジェクトの切り替えを行う
+/// </summary>
+public class PlayingSeParentSwitcher : MonoBehaviour
+{
+    // 再生が終了しているSEの親オブジェクトのトランスフォーム
+    [SerializeField] Transform parentEndSe = default;
+
+    /// <summary>
+    /// 更新
+    /// </summary>
+    void Update()
+    {
+        for (int i = 0; i < transform.childCount; i++)
+        {
+            // 子オブジェクトを取得
+            GameObject childSe = transform.GetChild(i).gameObject;
+
+            // 子オブジェクトの中で既に再生が終了しているSEは専用の親オブジェクトに切り替える
+            if (!childSe.activeSelf)
+            {
+                childSe.transform.SetParent(parentEndSe);
+            }
+        }
+    }
+}

--- a/BattaJump/Assets/Script/Audio/PlayingSeParentSwitcher.cs
+++ b/BattaJump/Assets/Script/Audio/PlayingSeParentSwitcher.cs
@@ -9,22 +9,31 @@ public class PlayingSeParentSwitcher : MonoBehaviour
 {
     // 再生が終了しているSEの親オブジェクトのトランスフォーム
     [SerializeField] Transform parentEndSe = default;
+    // 前フレームの子オブジェクト数
+    int prevChildCount = 0;
 
     /// <summary>
     /// 更新
     /// </summary>
     void Update()
     {
-        for (int i = 0; i < transform.childCount; i++)
+        // 子オブジェクトの数が前フレームから変動したら
+        if (prevChildCount != transform.childCount)
         {
-            // 子オブジェクトを取得
-            GameObject childSe = transform.GetChild(i).gameObject;
-
-            // 子オブジェクトの中で既に再生が終了しているSEは専用の親オブジェクトに切り替える
-            if (!childSe.activeSelf)
+            for (int i = 0; i < transform.childCount; i++)
             {
-                childSe.transform.SetParent(parentEndSe);
+                // 子オブジェクトを取得
+                GameObject childSe = transform.GetChild(i).gameObject;
+
+                // 子オブジェクトの中で既に再生が終了しているSEは専用の親オブジェクトに切り替える
+                if (!childSe.activeSelf)
+                {
+                    childSe.transform.SetParent(parentEndSe);
+                }
             }
         }
+
+        // 現在の子オブジェクトの数を前フレームとして登録
+        prevChildCount = transform.childCount;
     }
 }

--- a/BattaJump/Assets/Script/Audio/PlayingSeParentSwitcher.cs.meta
+++ b/BattaJump/Assets/Script/Audio/PlayingSeParentSwitcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c0e2da6d2f86f640afb14d317f85c2c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
プッシュの段階でこのブランチの派生ブランチがマージされてしまったので、新たにブランチを作成してプルリクを出しなおしました。

>[MUST]
>Updateのなかでこれやると毎フレームすべての子オブジェクトを検索していて非常に重いです
>この更新を行うのは子が増減したときのみのはず

前回のプルリクで出ていた上記の指摘箇所を修正した段階でプルリクを出しましたので確認をお願いします。

【確認ファイル】
PlayingSeParentSwitcher.cs
