### PR TITLE
新規アイテム取得演出、アイテムメーターとボタンのずれ修正

### DIFF
--- a/BattaJump/Assets/Animation/Result/ResultCanvasAnim.controller
+++ b/BattaJump/Assets/Animation/Result/ResultCanvasAnim.controller
@@ -8,7 +8,13 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: ResultCanvasAnim
   serializedVersion: 5
-  m_AnimatorParameters: []
+  m_AnimatorParameters:
+  - m_Name: FadeIn
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -22,6 +28,58 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1101 &1101506992787531706
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: FadeIn
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102786648067706188}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &1102720384189446144
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NotAnim
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 1101506992787531706}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 0}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1102 &1102786648067706188
 AnimatorState:
   serializedVersion: 5
@@ -59,6 +117,9 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 1102786648067706188}
+    m_Position: {x: 252, y: 192, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1102720384189446144}
     m_Position: {x: 252, y: 120, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
@@ -69,4 +130,4 @@ AnimatorStateMachine:
   m_EntryPosition: {x: 50, y: 120, z: 0}
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
-  m_DefaultState: {fileID: 1102786648067706188}
+  m_DefaultState: {fileID: 1102720384189446144}

--- a/BattaJump/Assets/Animation/Result/ResultCanvasFadeIn.anim
+++ b/BattaJump/Assets/Animation/Result/ResultCanvasFadeIn.anim
@@ -113,4 +113,11 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0.33333334
+    functionName: End
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/BattaJump/Assets/CanvasActive.cs
+++ b/BattaJump/Assets/CanvasActive.cs
@@ -19,6 +19,8 @@ public class CanvasActive : MonoBehaviour
     void DisplayCanvas()
     {
         dirtSmoke.SetActive(false);
+
+        //カンバス表示用アニメーション再生
         canvasAnim.SetTrigger("FadeIn");
     }
 }

--- a/BattaJump/Assets/CanvasActive.cs
+++ b/BattaJump/Assets/CanvasActive.cs
@@ -11,7 +11,7 @@ public class CanvasActive : MonoBehaviour
     GameObject dirtSmoke = default;    //土煙
 
     [SerializeField]
-    GameObject canvas = default;       //カンバス
+    Animator canvasAnim = default;     //カンバスのアニメーター
 
     /// <summary>
     /// カンバス表示
@@ -19,6 +19,6 @@ public class CanvasActive : MonoBehaviour
     void DisplayCanvas()
     {
         dirtSmoke.SetActive(false);
-        canvas.SetActive(true);
+        canvasAnim.SetTrigger("FadeIn");
     }
 }

--- a/BattaJump/Assets/NewItemsDisplay.cs
+++ b/BattaJump/Assets/NewItemsDisplay.cs
@@ -32,7 +32,7 @@ public class NewItemsDisplay : MonoBehaviour
     SpriteAtlas itemAtlas = default;                  //アイテムのスプライトアトラス
 
     [SerializeField]
-    GameObject displayImage = default;                //アイテム取得パネル表示用イメージ
+    GameObject displayImage = default;                //アイテム取得演出表示用イメージ(子に名前と画像)
 
     [SerializeField]
     int touchCount = 0;     //タッチ数カウント
@@ -54,6 +54,8 @@ public class NewItemsDisplay : MonoBehaviour
         else
         {
             SetNewItem();
+
+            //アイテム取得演出表示
             displayImage.SetActive(true);
         }
     }

--- a/BattaJump/Assets/NewItemsDisplay.cs
+++ b/BattaJump/Assets/NewItemsDisplay.cs
@@ -65,11 +65,15 @@ public class NewItemsDisplay : MonoBehaviour
     /// </summary>
     void Update()
     {
+        //最初のタッチがされるまで
+        //NOTE:Startで呼ぶとちらつきとが目立つため、Updateに
         if(touchCount == 0)
         {
             //最初の表示
             itemDescription.NewItemDescription(itemAtlas.GetSprite(ItemScriptableObject.Instance.GetName(newHasNum[0])), names[0], descriptions[0]);
         }
+
+        //タッチされたら
         if (Input.touchCount > 0)
         {
             // タッチの情報を取得

--- a/BattaJump/Assets/NewItemsDisplay.cs
+++ b/BattaJump/Assets/NewItemsDisplay.cs
@@ -32,6 +32,9 @@ public class NewItemsDisplay : MonoBehaviour
     SpriteAtlas itemAtlas = default;                  //アイテムのスプライトアトラス
 
     [SerializeField]
+    GameObject displayImage = default;                //アイテム取得パネル表示用イメージ
+
+    [SerializeField]
     int touchCount = 0;     //タッチ数カウント
 
     /// <summary>
@@ -51,8 +54,7 @@ public class NewItemsDisplay : MonoBehaviour
         else
         {
             SetNewItem();
-            itemDescription.NewItemDescription(itemAtlas.GetSprite(ItemScriptableObject.Instance.GetName(newHasNum[0])), names[0], descriptions[0]);
-            //最初の表示
+            displayImage.SetActive(true);
         }
     }
 
@@ -61,6 +63,11 @@ public class NewItemsDisplay : MonoBehaviour
     /// </summary>
     void Update()
     {
+        if(touchCount == 0)
+        {
+            //最初の表示
+            itemDescription.NewItemDescription(itemAtlas.GetSprite(ItemScriptableObject.Instance.GetName(newHasNum[0])), names[0], descriptions[0]);
+        }
         if (Input.touchCount > 0)
         {
             // タッチの情報を取得

--- a/BattaJump/Assets/Prefabs/Item/ItemBoxManager.prefab
+++ b/BattaJump/Assets/Prefabs/Item/ItemBoxManager.prefab
@@ -1,5 +1,100 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &519576711457502685
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5747805609231127775}
+  - component: {fileID: 3523987908593217544}
+  - component: {fileID: 1271255957298612361}
+  - component: {fileID: 4920794926315076696}
+  m_Layer: 5
+  m_Name: NewText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5747805609231127775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519576711457502685}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3625069118039901195}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 7.5, y: 16.4}
+  m_SizeDelta: {x: 50, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3523987908593217544
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519576711457502685}
+  m_CullTransparentMesh: 0
+--- !u!114 &1271255957298612361
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519576711457502685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: New!!
+--- !u!114 &4920794926315076696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519576711457502685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -900027084, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: 1, y: -1}
+  m_UseGraphicAlpha: 1
 --- !u!1 &3443115828048440631
 GameObject:
   m_ObjectHideFlags: 0
@@ -146,12 +241,13 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 3625069119677232619}
+  - {fileID: 5747805609231127775}
   m_Father: {fileID: 484919881806323683}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -188.48087, y: -84.999985}
+  m_AnchoredPosition: {x: -500, y: -84.999985}
   m_SizeDelta: {x: 50, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3625069118039901198
@@ -244,7 +340,7 @@ MonoBehaviour:
         m_CallState: 2
       - m_Target: {fileID: 7840694261364005236, guid: 9c9d125a9ea3ec449a078493600f749d,
           type: 3}
-        m_MethodName: PlayCancelButtonSound
+        m_MethodName: PlaySelectButtonSound
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -449,6 +545,18 @@ MonoBehaviour:
       - m_Target: {fileID: 3443115828048440631}
         m_MethodName: SetActive
         m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 7840694261364005236, guid: 9c9d125a9ea3ec449a078493600f749d,
+          type: 3}
+        m_MethodName: PlayCancelButtonSound
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1142,7 +1250,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0.9678899, y: 1}
   m_AnchoredPosition: {x: 0, y: -2}
-  m_SizeDelta: {x: -209, y: 4}
+  m_SizeDelta: {x: -458.7156, y: 4}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!114 &3625069119680069422
 MonoBehaviour:

--- a/BattaJump/Assets/Prefabs/Item/ItemMeter.prefab
+++ b/BattaJump/Assets/Prefabs/Item/ItemMeter.prefab
@@ -263,7 +263,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -63, y: 230}
+  m_AnchoredPosition: {x: -30, y: 122}
   m_SizeDelta: {x: 20, y: 300}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &3198779632647248248
@@ -304,6 +304,7 @@ MonoBehaviour:
   - {fileID: 6214314027930885451}
   - {fileID: 1795235534537921385}
   - {fileID: 501663135121160308}
+  cameraMove: {fileID: 0}
 --- !u!1 &6684485729469556433
 GameObject:
   m_ObjectHideFlags: 0
@@ -596,7 +597,7 @@ PrefabInstance:
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}
@@ -727,7 +728,7 @@ PrefabInstance:
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}
@@ -858,7 +859,7 @@ PrefabInstance:
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}
@@ -989,7 +990,7 @@ PrefabInstance:
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 872053933752884262, guid: 7cedea4ed8e5c4b46a7fab569b3dced5,
         type: 3}

--- a/BattaJump/Assets/Prefabs/Item/NewItemDisPlay.prefab
+++ b/BattaJump/Assets/Prefabs/Item/NewItemDisPlay.prefab
@@ -274,7 +274,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3815690988202314367}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
@@ -344,6 +344,7 @@ MonoBehaviour:
   isNewHasItem: 0000000000000000000000000000000000000000000000000000000000000000000000000000
   itemAtlas: {fileID: 4343727234628468602, guid: fc6ce9b6cc5714daebacd0a4932eba03,
     type: 2}
+  displayImage: {fileID: 8369506692665053775}
   touchCount: 0
 --- !u!1 &8201142471552510363
 GameObject:
@@ -412,7 +413,7 @@ MonoBehaviour:
       Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 12
+    m_FontSize: 13
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 1
@@ -436,12 +437,12 @@ GameObject:
   - component: {fileID: 637576243284909332}
   - component: {fileID: 7087016362250846769}
   m_Layer: 5
-  m_Name: Image
+  m_Name: DisplayImage
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8973551772415925025
 RectTransform:
   m_ObjectHideFlags: 0

--- a/BattaJump/Assets/Scenes/Result.unity
+++ b/BattaJump/Assets/Scenes/Result.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4774822, g: 0.6249047, b: 0.7200886, a: 1}
+  m_IndirectSpecularColor: {r: 0.4810514, g: 0.62701726, b: 0.7170462, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -184,6 +184,11 @@ PrefabInstance:
       propertyPath: canvas
       value: 
       objectReference: {fileID: 7573624243915292178}
+    - target: {fileID: 6951135743852118565, guid: e3278165567384a05b7a157c35ffa6d7,
+        type: 3}
+      propertyPath: canvasAnim
+      value: 
+      objectReference: {fileID: 7573624243915292181}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e3278165567384a05b7a157c35ffa6d7, type: 3}
 --- !u!1 &76888469 stripped
@@ -211,16 +216,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3774517793028411111, guid: 2e1ae328a971661408f221749c16738d,
-        type: 3}
-      propertyPath: playData
-      value: 
-      objectReference: {fileID: 1341260704}
-    - target: {fileID: 3774517793028411111, guid: 2e1ae328a971661408f221749c16738d,
-        type: 3}
-      propertyPath: itemData
-      value: 
-      objectReference: {fileID: 1341260703}
     - target: {fileID: 3774517793028411108, guid: 2e1ae328a971661408f221749c16738d,
         type: 3}
       propertyPath: m_Name
@@ -231,6 +226,16 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
+    - target: {fileID: 3774517793028411111, guid: 2e1ae328a971661408f221749c16738d,
+        type: 3}
+      propertyPath: playData
+      value: 
+      objectReference: {fileID: 1341260704}
+    - target: {fileID: 3774517793028411111, guid: 2e1ae328a971661408f221749c16738d,
+        type: 3}
+      propertyPath: itemData
+      value: 
+      objectReference: {fileID: 1341260703}
     - target: {fileID: 3774517793028411110, guid: 2e1ae328a971661408f221749c16738d,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -854,12 +859,17 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
+    - target: {fileID: 4289783532495208795, guid: a05e7cfb4f0d77944b042c7d4bc26781,
+        type: 3}
+      propertyPath: m_StaticEditorFlags
+      value: 4294967295
+      objectReference: {fileID: 0}
     - target: {fileID: 4315130577745593639, guid: a05e7cfb4f0d77944b042c7d4bc26781,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
-    - target: {fileID: 4289783532495208795, guid: a05e7cfb4f0d77944b042c7d4bc26781,
+    - target: {fileID: 4786346490017275827, guid: a05e7cfb4f0d77944b042c7d4bc26781,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
@@ -870,11 +880,6 @@ PrefabInstance:
       value: 4294967295
       objectReference: {fileID: 0}
     - target: {fileID: 6839767070073463541, guid: a05e7cfb4f0d77944b042c7d4bc26781,
-        type: 3}
-      propertyPath: m_StaticEditorFlags
-      value: 4294967295
-      objectReference: {fileID: 0}
-    - target: {fileID: 4786346490017275827, guid: a05e7cfb4f0d77944b042c7d4bc26781,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 4294967295
@@ -1169,11 +1174,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 8152976358101605184, guid: b8022a5de8e002a4f8143c2ddbc488b2,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 8152976357676658781, guid: b8022a5de8e002a4f8143c2ddbc488b2,
         type: 3}
       propertyPath: m_IsActive
@@ -1183,16 +1183,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_RootOrder
       value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 8152976358350929390, guid: b8022a5de8e002a4f8143c2ddbc488b2,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8152976357535158004, guid: b8022a5de8e002a4f8143c2ddbc488b2,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4793243374622371490, guid: b8022a5de8e002a4f8143c2ddbc488b2,
         type: 3}
@@ -1253,6 +1243,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8152976358101605184, guid: b8022a5de8e002a4f8143c2ddbc488b2,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8152976357535158004, guid: b8022a5de8e002a4f8143c2ddbc488b2,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8152976358350929390, guid: b8022a5de8e002a4f8143c2ddbc488b2,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b8022a5de8e002a4f8143c2ddbc488b2, type: 3}
@@ -1594,16 +1599,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3787169931983882066, guid: 05180de82c3924066b9f334f83e8e688,
-        type: 3}
-      propertyPath: scoreData
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 3787169931983882066, guid: 05180de82c3924066b9f334f83e8e688,
-        type: 3}
-      propertyPath: playData
-      value: 
-      objectReference: {fileID: 1341260704}
     - target: {fileID: 3787169931983882068, guid: 05180de82c3924066b9f334f83e8e688,
         type: 3}
       propertyPath: m_Name
@@ -1614,6 +1609,16 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 4294967295
       objectReference: {fileID: 0}
+    - target: {fileID: 3787169931983882066, guid: 05180de82c3924066b9f334f83e8e688,
+        type: 3}
+      propertyPath: scoreData
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 3787169931983882066, guid: 05180de82c3924066b9f334f83e8e688,
+        type: 3}
+      propertyPath: playData
+      value: 
+      objectReference: {fileID: 1341260704}
     - target: {fileID: 3787169931983882067, guid: 05180de82c3924066b9f334f83e8e688,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1990,13 +1995,58 @@ PrefabInstance:
     - target: {fileID: 5870461471416807794, guid: 1e9033abff0344a4b939712309fbc198,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0.000015258789
+      value: 0.000030517578
+      objectReference: {fileID: 0}
+    - target: {fileID: 7573624244775667718, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7573624245677273001, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_Alpha
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9004992120099546342, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512336068552507366, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: itemDataManager
+      value: 
+      objectReference: {fileID: 1341260703}
+    - target: {fileID: 5181045664717216865, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512336070247616126, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -234.20064
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512336070290799330, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6512336070290799330, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8006074447057077387, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1e9033abff0344a4b939712309fbc198, type: 3}
 --- !u!114 &7573624243915292175 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5870461469722788074, guid: 1e9033abff0344a4b939712309fbc198,
+  m_CorrespondingSourceObject: {fileID: 6512336068552507366, guid: 1e9033abff0344a4b939712309fbc198,
     type: 3}
   m_PrefabInstance: {fileID: 7573624243915292174}
   m_PrefabAsset: {fileID: 0}
@@ -2027,6 +2077,12 @@ MonoBehaviour:
 --- !u!1 &7573624243915292178 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7573624244775667718, guid: 1e9033abff0344a4b939712309fbc198,
+    type: 3}
+  m_PrefabInstance: {fileID: 7573624243915292174}
+  m_PrefabAsset: {fileID: 0}
+--- !u!95 &7573624243915292181 stripped
+Animator:
+  m_CorrespondingSourceObject: {fileID: 4316543420074996311, guid: 1e9033abff0344a4b939712309fbc198,
     type: 3}
   m_PrefabInstance: {fileID: 7573624243915292174}
   m_PrefabAsset: {fileID: 0}

--- a/BattaJump/Assets/Scenes/Result.unity
+++ b/BattaJump/Assets/Scenes/Result.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4810514, g: 0.62701726, b: 0.7170462, a: 1}
+  m_IndirectSpecularColor: {r: 0.48080522, g: 0.6271093, b: 0.71705496, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1852,6 +1852,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: ResultCanvas
       objectReference: {fileID: 0}
+    - target: {fileID: 7573624246038248667, guid: 1e9033abff0344a4b939712309fbc198,
+        type: 3}
+      propertyPath: itemDescription
+      value: 
+      objectReference: {fileID: 7573624243915292179}
     - target: {fileID: 7573624245677272997, guid: 1e9033abff0344a4b939712309fbc198,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -2000,7 +2005,7 @@ PrefabInstance:
     - target: {fileID: 7573624244775667718, guid: 1e9033abff0344a4b939712309fbc198,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7573624245677273001, guid: 1e9033abff0344a4b939712309fbc198,
         type: 3}
@@ -2080,6 +2085,18 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7573624243915292174}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7573624243915292179 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6512336068552507365, guid: 1e9033abff0344a4b939712309fbc198,
+    type: 3}
+  m_PrefabInstance: {fileID: 7573624243915292174}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd81aaabd06d0d0409b67e397175c975, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!95 &7573624243915292181 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 4316543420074996311, guid: 1e9033abff0344a4b939712309fbc198,

--- a/BattaJump/Assets/Script/ItemButtonCreater.cs
+++ b/BattaJump/Assets/Script/ItemButtonCreater.cs
@@ -58,12 +58,19 @@ public class ItemButtonCreater : MonoBehaviour
             //ボタンのアイテムゲット
             for (int i = 0; i < ItemManager.ItemNum; i++)
             {
-                Image buttonImage = buttons[i].transform.FindChild("ItemImage").GetComponent<Image>();
+                Image buttonImage = buttons[i].transform.FindChild("ItemImage").GetComponent<Image>();  //各アイテムボタンのイメージ
+                GameObject newItemText = buttons[i].transform.FindChild("NewText").gameObject;          //New!!というテキスト
 
                 //ゲットしているなら実態、していないならシルエットのみ
                 if (itemManager.GetIsHasItem(i))
                 {
                     buttonImage.sprite = existenceSpriteAtlas.GetSprite(atlasKey[i]);
+
+                    //テキスト表示
+                    if(itemManager.GetIsNewHasItem(i) == true)
+                    {
+                        newItemText.SetActive(true);
+                    }
                 }
                 else
                 {

--- a/BattaJump/Assets/Script/ItemCreater.cs
+++ b/BattaJump/Assets/Script/ItemCreater.cs
@@ -29,9 +29,9 @@ public class ItemCreater : MonoBehaviour
 
     public const int appearanceNum = 4;                         //表示数
 
-    float skyBorder = 5000;                                      //空の境目
-    float spaceItemInterval = 1000;                              //宇宙のアイテムの間隔
-    float spaceItemPlusInterval = 500;                           //宇宙のアイテムの間隔の増加値
+    const float skyBorder = 5000;                                      //空の境目
+    const float spaceItemInterval = 1000;                              //宇宙のアイテムの間隔
+    const float spaceItemPlusInterval = 500;                           //宇宙のアイテムの間隔の増加値
 
     /// <summary>
     /// 開始処理

--- a/BattaJump/Assets/Script/ItemCreater.cs
+++ b/BattaJump/Assets/Script/ItemCreater.cs
@@ -28,11 +28,9 @@ public class ItemCreater : MonoBehaviour
     List<float> existAllItemsRate = new List<float>();          //表示されるアイテムの出現確立
 
     public const int appearanceNum = 4;                         //表示数
-    [SerializeField]
+
     float skyBorder = 5000;                                      //空の境目
-    [SerializeField]
     float spaceItemInterval = 1000;                              //宇宙のアイテムの間隔
-    [SerializeField]
     float spaceItemPlusInterval = 500;                           //宇宙のアイテムの間隔の増加値
 
     /// <summary>

--- a/BattaJump/Assets/Script/ItemCreater.cs
+++ b/BattaJump/Assets/Script/ItemCreater.cs
@@ -29,11 +29,11 @@ public class ItemCreater : MonoBehaviour
 
     public const int appearanceNum = 4;                         //表示数
     [SerializeField]
-    float skyBorder = 300;                                      //空の境目
+    float skyBorder = 5000;                                      //空の境目
     [SerializeField]
-    float spaceItemInterval = 350;                              //宇宙のアイテムの間隔
+    float spaceItemInterval = 1000;                              //宇宙のアイテムの間隔
     [SerializeField]
-    float spaceItemPlusInterval = 50;                           //宇宙のアイテムの間隔の増加値
+    float spaceItemPlusInterval = 500;                           //宇宙のアイテムの間隔の増加値
 
     /// <summary>
     /// 開始処理

--- a/BattaJump/Assets/Script/ItemDistanceMeter.cs
+++ b/BattaJump/Assets/Script/ItemDistanceMeter.cs
@@ -33,8 +33,6 @@ public class ItemDistanceMeter : MonoBehaviour
     [SerializeField]
     CameraMoveController cameraMove = default;                      //カメラの動き制御
 
-    float arrowMargin = 25;                                         //矢印分の余白
-
     bool isChildActive = false;                                     //子オブジェクト表示フラグ
 
     bool isCreate = false;                                          //メーターが生成されたかどうかのフラグ
@@ -117,7 +115,7 @@ public class ItemDistanceMeter : MonoBehaviour
                 }
                 else
                 {
-                    iconList[i].transform.position = iconList[0].transform.position + new Vector3(arrowMargin, (posDifference[i - 1]), 0);
+                    iconList[i].transform.position = new Vector3(iconList[i].transform.position.x, iconList[0].transform.position.y + (posDifference[i - 1]), 0);
 
                     //メーターの座標が表示の最大距離を上回ったなら最大距離内に収める
                     if (iconList[i].transform.position.y > iconList[0].transform.position.y + maxDistance)

--- a/BattaJump/Assets/Script/ItemManager.cs
+++ b/BattaJump/Assets/Script/ItemManager.cs
@@ -56,11 +56,31 @@ public class ItemManager : MonoBehaviour
     }
 
     /// <summary>
-    /// 新しく入手したアイテムのフラグのゲット関数
+    /// 新しく入手したアイテムのフラグのゲット関数(全部)
     /// </summary>
     /// <returns>新しく入手したアイテムのフラグ</returns>
     public bool[] GetIsNewHasItem()
     {
         return isNewHasItem;
+    }
+
+    /// <summary>
+    /// 新しく入手したアイテムのフラグのゲット関数(1個ずつ)
+    /// </summary>
+    /// <returns>新しく入手したアイテムのフラグ</returns>
+    public bool GetIsNewHasItem(int i)
+    {
+        return isNewHasItem[i];
+    }
+
+    /// <summary>
+    /// 新規取得アイテムフラグリセット
+    /// </summary>
+    public void ResetIsNewHasItem()
+    {
+        for (int i = 0; i < isNewHasItem.Length; i++) 
+        {
+            isNewHasItem[i] = false;
+        }
     }
 }


### PR DESCRIPTION
バグで出なかった新規アイテム取得演出とアイテム系のUIの修正を行いました。
変更したスクリプトは
CanvasActive.cs -> カンバスのアニメーション追加
NewItemsDisplay.cs -> 新規アイテム取得演出時のちらつき、最初の表示が必ず小人になるバグを修正
ItemButtonCreater.cs -> リザルトの新規取得のアイテムボタンの上にNew!!というテキストを追加
ItemCreater.cs -> アイテム出現位置の高さ調整
ItemDistanceMeter.cs -> 位置がずれないようにシーン上で調整するようにした
ItemManager.cs -> ゲット関数、リセット関数追加
