### PR TITLE
AdMobのIDをAndroidとIOSで分けるよう修正、ロードが長い場合強制的に次のフェーズへ移行するよう修正

### DIFF
--- a/BattaJump/.idea/workspace.xml
+++ b/BattaJump/.idea/workspace.xml
@@ -11,20 +11,19 @@
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/Temp/gradleOut/src/main/res/values/strings.xml">
-          <provider selected="true" editor-type-id="text-editor" />
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/Temp/gradleOut/src/main/AndroidManifest.xml">
-          <provider selected="true" editor-type-id="text-editor" />
+        <entry file="file://$PROJECT_DIR$/Assets/Plugins/Android/AndroidManifest.xml">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="459">
+              <caret line="27" column="62" selection-start-line="27" selection-start-column="62" selection-end-line="27" selection-end-column="62" />
+            </state>
+          </provider>
         </entry>
       </file>
       <file pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/Temp/gradleOut/unity-android-resources/build.gradle">
+        <entry file="file://$PROJECT_DIR$/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="374">
-              <caret line="22" column="33" lean-forward="true" selection-start-line="22" selection-start-column="33" selection-end-line="22" selection-end-column="33" />
+            <state relative-caret-position="289">
+              <caret line="17" column="57" selection-start-line="17" selection-start-column="57" selection-end-line="17" selection-end-column="57" />
             </state>
           </provider>
         </entry>
@@ -40,8 +39,8 @@
         <option value="$PROJECT_DIR$/Temp/StagingArea/res/values/strings.xml" />
         <option value="$PROJECT_DIR$/Assets/GooglePlayGames/Plugins/Android/GooglePlayGamesManifest.plugin/AndroidManifest.xml" />
         <option value="$USER_HOME$/AppData/Local/Temp/AndroidManifest.xml" />
-        <option value="$PROJECT_DIR$/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml" />
         <option value="$PROJECT_DIR$/Assets/Plugins/Android/AndroidManifest.xml" />
+        <option value="$PROJECT_DIR$/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml" />
       </list>
     </option>
   </component>
@@ -57,29 +56,50 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="PackagesPane" />
       <pane id="ProjectPane">
         <subPane>
           <expand>
             <path>
-              <item name="GooglePlayGameTest" type="b2602c69:ProjectViewProjectNode" />
-              <item name="GooglePlayGameTest" type="462c0819:PsiDirectoryNode" />
+              <item name="BattaJump" type="b2602c69:ProjectViewProjectNode" />
+              <item name="BattaJump" type="462c0819:PsiDirectoryNode" />
             </path>
             <path>
-              <item name="GooglePlayGameTest" type="b2602c69:ProjectViewProjectNode" />
-              <item name="GooglePlayGameTest" type="462c0819:PsiDirectoryNode" />
+              <item name="BattaJump" type="b2602c69:ProjectViewProjectNode" />
+              <item name="BattaJump" type="462c0819:PsiDirectoryNode" />
               <item name="Assets" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="BattaJump" type="b2602c69:ProjectViewProjectNode" />
+              <item name="BattaJump" type="462c0819:PsiDirectoryNode" />
+              <item name="Assets" type="462c0819:PsiDirectoryNode" />
+              <item name="Plugins" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="BattaJump" type="b2602c69:ProjectViewProjectNode" />
+              <item name="BattaJump" type="462c0819:PsiDirectoryNode" />
+              <item name="Assets" type="462c0819:PsiDirectoryNode" />
+              <item name="Plugins" type="462c0819:PsiDirectoryNode" />
+              <item name="Android" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="BattaJump" type="b2602c69:ProjectViewProjectNode" />
+              <item name="BattaJump" type="462c0819:PsiDirectoryNode" />
+              <item name="Assets" type="462c0819:PsiDirectoryNode" />
+              <item name="Plugins" type="462c0819:PsiDirectoryNode" />
+              <item name="Android" type="462c0819:PsiDirectoryNode" />
+              <item name="GoogleMobileAdsPlugin" type="462c0819:PsiDirectoryNode" />
             </path>
           </expand>
           <select />
         </subPane>
       </pane>
+      <pane id="PackagesPane" />
       <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
     <property name="android.sdk.path" value="$USER_HOME$/AppData/Local/Android/Sdk" />
-    <property name="last_opened_file_path" value="$PROJECT_DIR$/../../GooglePlayGameTest" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
     <property name="settings.editor.selected.configurable" value="AndroidSdkUpdater" />
   </component>
   <component name="RunDashboard">
@@ -137,46 +157,24 @@
       </provider>
     </entry>
     <entry file="file://$USER_HOME$/AppData/Local/Temp/AndroidManifest.xml" />
-    <entry file="file://$PROJECT_DIR$/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="306">
-          <caret line="18" column="16" selection-start-line="18" selection-start-column="16" selection-end-line="18" selection-end-column="16" />
-        </state>
-      </provider>
-    </entry>
+    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/build.gradle" />
+    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/GooglePlayGamesManifest.plugin/build.gradle" />
+    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/GoogleMobileAdsPlugin/AndroidManifest.xml" />
+    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/GoogleMobileAdsPlugin/build.gradle" />
+    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/src/main/res/values/strings.xml" />
+    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/src/main/AndroidManifest.xml" />
+    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/unity-android-resources/build.gradle" />
     <entry file="file://$PROJECT_DIR$/Assets/Plugins/Android/AndroidManifest.xml">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="374">
-          <caret line="22" column="57" selection-start-line="22" selection-start-column="57" selection-end-line="22" selection-end-column="57" />
+        <state relative-caret-position="459">
+          <caret line="27" column="62" selection-start-line="27" selection-start-column="62" selection-end-line="27" selection-end-column="62" />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/build.gradle">
+    <entry file="file://$PROJECT_DIR$/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="986">
-          <caret line="58" column="52" lean-forward="true" selection-start-line="58" selection-start-column="52" selection-end-line="58" selection-end-column="52" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/GooglePlayGamesManifest.plugin/build.gradle">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/GoogleMobileAdsPlugin/AndroidManifest.xml">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/GoogleMobileAdsPlugin/build.gradle">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/src/main/res/values/strings.xml">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/src/main/AndroidManifest.xml">
-      <provider selected="true" editor-type-id="text-editor" />
-    </entry>
-    <entry file="file://$PROJECT_DIR$/Temp/gradleOut/unity-android-resources/build.gradle">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="374">
-          <caret line="22" column="33" lean-forward="true" selection-start-line="22" selection-start-column="33" selection-end-line="22" selection-end-column="33" />
+        <state relative-caret-position="289">
+          <caret line="17" column="57" selection-start-line="17" selection-start-column="57" selection-end-line="17" selection-end-column="57" />
         </state>
       </provider>
     </entry>

--- a/BattaJump/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml
+++ b/BattaJump/Assets/Plugins/Android/GoogleMobileAdsPlugin/AndroidManifest.xml
@@ -15,6 +15,6 @@ required for displaying ads.
     ca-app-pub-3940256099942544~3347511713 -->
     <meta-data
     android:name="com.google.android.gms.ads.APPLICATION_ID"
-    android:value="ca-app-pub-3940256099942544~3347511713"/>
+    android:value="ca-app-pub-7073050807259252~7297201289"/>
   </application>
 </manifest>

--- a/BattaJump/Assets/Script/Ad/AdMob/AdBannerController.cs
+++ b/BattaJump/Assets/Script/Ad/AdMob/AdBannerController.cs
@@ -12,7 +12,14 @@ public class AdBannerController : MonoBehaviour
 {
     BannerView bannerView;                                              // バナー広告制御クラス
 
-    const string AdUnitId = "ca-app-pub-3940256099942544/6300978111";   // 広告ユニットID（テスト用ID）
+    const string AdUnitId =                                             // 広告ユニットID（テスト用ID）
+#if UNITY_ANDROID
+        "ca-app-pub-3940256099942544/6300978111";
+#elif UNITY_IOS
+        "ca-app-pub-3940256099942544/2934735716";
+#else
+        "unexpected_platform";
+#endif
 
     public bool IsLoaded { get; private set; } = false;                 // ロード完了フラグ
 
@@ -21,13 +28,13 @@ public class AdBannerController : MonoBehaviour
     /// </summary>
     public void RequestBanner()
     {
-        // リザルトの時のみ表示位置を上にする
-        if (SceneManager.GetActiveScene().name == "Result")
-        {
-            // サイズ320 x 50、画面上部表示の設定で初期化
-            bannerView = new BannerView(AdUnitId, AdSize.Banner, AdPosition.Top);
-        }
-        else
+        //// リザルトの時のみ表示位置を上にする
+        //if (SceneManager.GetActiveScene().name == "Result")
+        //{
+        //    // サイズ320 x 50、画面上部表示の設定で初期化
+        //    bannerView = new BannerView(AdUnitId, AdSize.Banner, AdPosition.Top);
+        //}
+        //else
         {
             // サイズ320 x 50、画面下部表示の設定で初期化
             bannerView = new BannerView(AdUnitId, AdSize.Banner, AdPosition.Bottom);

--- a/BattaJump/Assets/Script/Ad/AdMob/AdInterstitialController.cs
+++ b/BattaJump/Assets/Script/Ad/AdMob/AdInterstitialController.cs
@@ -11,7 +11,14 @@ public class AdInterstitialController : MonoBehaviour
 {
     InterstitialAd interstitialAd;                                      // インタースティシャル広告制御クラス
 
-    const string AdUnitId = "ca-app-pub-3940256099942544/1033173712";   // 広告ユニットID（テスト用ID）
+    const string AdUnitId =                                             // 広告ユニットID（テスト用ID）
+#if UNITY_ANDROID
+        "ca-app-pub-3940256099942544/1033173712";
+#elif UNITY_IOS
+        "ca-app-pub-3940256099942544/4411468910";
+#else
+        "unexpected_platform";
+#endif
 
     public bool IsClosed { get; private set; }                          // 広告を閉じているかどうか
 

--- a/BattaJump/Assets/Script/Ad/AdMob/AdManager.cs
+++ b/BattaJump/Assets/Script/Ad/AdMob/AdManager.cs
@@ -14,9 +14,18 @@ public class AdManager : MonoBehaviour
     [SerializeField]
     AdInterstitialController adInterstitial = default;                // インタースティシャル広告テストクラス
 
-    const string AppId = "ca-app-pub-3824454621992610~6537798789";    // アプリID（テスト用）
+    const string AppId =                                              // アプリID
+#if UNITY_ANDROID
+        "ca-app-pub-7073050807259252~7297201289";
+#elif UNITY_IOS
+        "ca-app-pub-7073050807259252~7875785788";
+#else
+        "unexpected_platform";
+#endif
 
     public bool IsAdView { get; private set; }                        // 広告表示してるかどうか 
+
+    bool isOnline = false;                                            // オンラインかどうか
 
     /// <summary>
     /// ロード完了検知
@@ -24,8 +33,8 @@ public class AdManager : MonoBehaviour
     /// <returns></returns>
     public bool IsLoaded()
     {
-        // バナー、インタースティシャルどちらもロードが完了したらtrueを返す
-        if (adBanner.IsLoaded && adInterstitial.IsLoaded())
+        // バナー、インタースティシャルどちらもロードが完了したらtrueを返す、オフラインの場合も同様
+        if ((adBanner.IsLoaded && adInterstitial.IsLoaded()) || !isOnline)
         {
             return true;
         }
@@ -49,6 +58,19 @@ public class AdManager : MonoBehaviour
     /// </summary>
     void OnEnable()
     {
+        // オンラインかどうか判断
+        if (Application.internetReachability == NetworkReachability.NotReachable)
+        {
+            isOnline = false;
+        }
+        else
+        {
+            isOnline = true;
+        }
+
+        // オフラインなら処理を抜ける
+        if (!isOnline) { return; }
+
         // Google Mobile Ads SDKを設定したアプリIDで初期化.
         MobileAds.Initialize(AppId);
 
@@ -67,6 +89,9 @@ public class AdManager : MonoBehaviour
     /// </summary>
     public void ShowBanner()
     {
+        // オフラインなら処理を抜ける
+        if (!isOnline) { return; }
+
         adBanner.Show();
     }
 
@@ -75,6 +100,9 @@ public class AdManager : MonoBehaviour
     /// </summary>
     public void HideBanner()
     {
+        // オフラインなら処理を抜ける
+        if (!isOnline) { return; }
+
         adBanner.Hide();
     }
 
@@ -83,6 +111,9 @@ public class AdManager : MonoBehaviour
     /// </summary>
     public void ShowInterstitial()
     {
+        // オフラインなら処理を抜ける
+        if (!isOnline) { return; }
+
         // 閉じているなら表示する
         if (adInterstitial.IsClosed)
         {

--- a/BattaJump/Assets/Script/Phase/ResultPhaseState.cs
+++ b/BattaJump/Assets/Script/Phase/ResultPhaseState.cs
@@ -60,6 +60,9 @@ public class ResultPhaseState : MonoBehaviour
     [SerializeField]
     GameObject playerObj = default;
 
+    float loadTime = 0f;                             // ロード待機時間
+    const float LoadMaxTime = 3f;                    // ロード待機最大時間
+
     float landingTime = 0;                           // 着地のアニメーション再生時間
     const float LandingCraterCreateTime = 0.1f;      // 着地アニメーション中にクレーターを生成する時間
 
@@ -100,8 +103,10 @@ public class ResultPhaseState : MonoBehaviour
         {
             case PhaseType.WaitAdLoad:        // 広告ロード完了待機
 
+                loadTime += Time.deltaTime;
+
                 // 広告のロードが完了したら次の処理へ
-                if (adManager.IsLoaded())
+                if (adManager.IsLoaded() || loadTime >= LoadMaxTime)
                 {
                     // フェードアウト開始
                     fadeContoller.OnFade(DisplayFadeContoller.FadeType.FadeOut, DisplayFadeContoller.PanelType.White);

--- a/BattaJump/Assets/Script/Phase/TitlePhaseState.cs
+++ b/BattaJump/Assets/Script/Phase/TitlePhaseState.cs
@@ -33,6 +33,9 @@ public class TitlePhaseState : MonoBehaviour
     [SerializeField]
     NextSceneChanger nextScene = default;            // シーン移行クラス
 
+    float loadTime = 0f;                             // ロード待機時間
+    const float LoadMaxTime = 3f;                    // ロード待機最大時間
+
     /// <summary>
     /// 開始
     /// </summary>
@@ -61,8 +64,10 @@ public class TitlePhaseState : MonoBehaviour
         {
             case PhaseType.WaitAdLoad:        // 広告ロード完了待機
 
+                loadTime += Time.deltaTime;
+
                 // 広告のロードが完了したら次の処理へ
-                if (adManager.IsLoaded())
+                if (adManager.IsLoaded() || loadTime >= LoadMaxTime)
                 {
                     // フェードアウト開始
                     fadeContoller.OnFade(DisplayFadeContoller.FadeType.FadeOut, DisplayFadeContoller.PanelType.White);


### PR DESCRIPTION
・AdMob用の各スクリプトのIDをプラットフォームで分けるよう修正
・各フェーズで広告のロードが完了しない場合強制的に次のフェーズへ移行するよう修正

「AdManager.cs」「AdBannerController.cs」「AdInterstitialController.cs」
「TitlePhaseState.cs」「ResultPhaseState.cs」
上記5つのファイルの確認をお願いします。